### PR TITLE
Use prisma transactions instead of promise all

### DIFF
--- a/coin.service.ts
+++ b/coin.service.ts
@@ -1,0 +1,102 @@
+import { PrismaService } from '#services'
+import { HistoryType } from '@prisma/client'
+import { TransferDto, RefundDto, BalanceRes } from './dto'
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+
+@Injectable()
+export class CoinService {
+  readonly #_prisma: PrismaService
+
+  constructor(prisma: PrismaService) {
+    this.#_prisma = prisma
+  }
+
+  async transfer(payload: TransferDto): Promise<void> {
+    await this.#_prisma.$transaction(async (tx) => {
+      const coin = await tx.coin.findUnique({
+        where: {
+          userId: payload.userId,
+        },
+      })
+
+      if (!coin) {
+        throw new NotFoundException('User coin not found!')
+      }
+
+      if (coin.balance < payload.amount) {
+        throw new BadRequestException('Insufficient coin amount')
+      }
+
+      await Promise.all([
+        tx.coin.update({
+          where: {
+            id: coin.id,
+          },
+          data: {
+            balance: {
+              decrement: payload.amount,
+            },
+          },
+        }),
+        tx.history.create({
+          data: {
+            userId: payload.userId,
+            type: HistoryType.TRANSFER,
+            additional: JSON.stringify(payload.additional ?? {}),
+            amount: payload.amount,
+            description: 'payment',
+          },
+        }),
+      ])
+    })
+  }
+
+  async refund(payload: RefundDto): Promise<void> {
+    await this.#_prisma.$transaction(async (tx) => {
+      const coin = await tx.coin.findUnique({
+        where: {
+          userId: payload.userId,
+        },
+      })
+
+      if (!coin) {
+        throw new NotFoundException('User coin not found!')
+      }
+
+      await Promise.all([
+        tx.coin.update({
+          where: {
+            id: coin.id,
+          },
+          data: {
+            balance: {
+              increment: payload.amount,
+            },
+          },
+        }),
+        tx.history.create({
+          data: {
+            userId: payload.userId,
+            type: HistoryType.WITHDRAW,
+            additional: JSON.stringify(payload.additional ?? {}),
+            amount: payload.amount,
+            description: 'refund user coin',
+          },
+        }),
+      ])
+    })
+  }
+
+  async balance(userId: string): Promise<BalanceRes> {
+    const coin = await this.#_prisma.coin.upsert({
+      where: { userId },
+      create: { userId },
+      update: {},
+      select: { balance: true },
+    })
+
+    return {
+      balance: Number(coin.balance),
+    }
+  }
+}


### PR DESCRIPTION
Refactor `transfer` and `refund` methods to use Prisma transactions for atomicity and data consistency.

The previous implementation using `Promise.all` did not guarantee atomicity, meaning a partial update could occur if one operation succeeded and another failed. This change ensures that both the coin balance update and history creation either succeed together or fail together, preventing data inconsistencies in financial transactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c95ed3a-0051-4c12-ac95-21cfb901e9f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c95ed3a-0051-4c12-ac95-21cfb901e9f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

